### PR TITLE
Fix incorrect migration text around OBJE.FILE.FORM

### DIFF
--- a/_pages/migrate.md
+++ b/_pages/migrate.md
@@ -127,7 +127,7 @@ becomes this 7.0:
 
 GEDCOM 5.5.1 allowed the same tag in the same context to have different meaning depending on its payload type. This added significant implementation complexity and has been removed from v7.0.
 
-Any NOTE_RECORD in 5.5.1 should be replaced with a [SHARED_NOTE_RECORD](https://gedcom.io/specifications/GEDCOM7rc.html#SHARED_NOTE_RECORD) in 7.0.
+Any NOTE_RECORD in 5.5.1 should be replaced with a [SHARED_NOTE_RECORD](https://gedcom.io/specifications/FamilySearchGEDCOMv7.html#SHARED_NOTE_RECORD) in 7.0.
 
 This 5.5.1:
 
@@ -177,11 +177,13 @@ becomes this 7.0:
 
 0 @O1@
 1 FILE file:///d//Media/1896-02-04-John-Smith.jpg
-2 FORM jpg
+2 FORM image/jpeg
 2 TITL John Smith, February 4, 1896
 ```
 
-Take care to convert the `TITL` tag correctly. In the GEDCOM 5.5.1 MULTIMEDIA_LINK structure, the `TITL` tag is a substructure of the `OBJE` tag, but in the [MULTIMEDIA_RECORD](https://gedcom.io/specifications/GEDCOM7rc.html#MULTIMEDIA_RECORD) in both GEDCOM 5.5.1 and FamilySearch GEDCCOM 7.0, the `TITL` tag is a substructure of the `FILE` tag.
+Take care to convert the `TITL` tag correctly. In the GEDCOM 5.5.1 MULTIMEDIA_LINK structure, the `TITL` tag is a substructure of the `OBJE` tag, but in the [MULTIMEDIA_RECORD](https://gedcom.io/specifications/FamilySearchGEDCOMv7.html#MULTIMEDIA_RECORD) in both GEDCOM 5.5.1 and FamilySearch GEDCCOM 7.0, the `TITL` tag is a substructure of the `FILE` tag.
+
+Similarly, the `FORM` tag must be converted correctly.  In the GEDCOM 5.5.1 MULTIMEDIA_FORMAT structure, the `FORM` tag is a set of enumerated values, but in FamilySearch GEDCOM 7.0, it must be a valid [media type](https://www.iana.org/assignments/media-types/media-types.xhtml).
 
 ## Non-pointer SOUR Substructures
 


### PR DESCRIPTION
FORM must be a media type.

Signed-off-by: Dave Thaler <dthaler@armidalesoftware.com>