### PR TITLE
Revert "Public pages"

### DIFF
--- a/_pages/community.md
+++ b/_pages/community.md
@@ -14,11 +14,9 @@ This is the open discussion and mailing group related to GEDCOM in general.
 The discussions are visible to all at [FamilySearch/GEDCOM Discussions](https://github.com/FamilySearch/GEDCOM/discussions);
 you can post to it after creating a free github account.
 Subscribe to the mailing list via the "Watch" button at the top of the page.
-## Public Repositories
+## Public Repository
 
-Become a GitHub GEDCOM Contributor for the next version by contributing to the [FamilySearch GEDCOM Specification](https://github.com/familysearch/GEDCOM) public repository.
-
-Become a GEDCOM.io website contributor by contributing to the [GEDCOM.io](https://github.com/familysearch/GEDCOM.io) public repository.
+Become a GitHub contributor for the next version by contributing to the [FamilySearch GEDCOM](https://github.com/familysearch/GEDCOM) public repository.
 
 ## Issue Tracker 
 

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -23,13 +23,10 @@ feature_row:
     btn_label: "Learn More"
   - image_path: mm-public-feature1.png
     alt: "public access"
-    title: "GitHub Public Repositories"
-    excerpt: "Join the public repositories for the GEDCOM 7 File Specification and the webpages on GEDCOM.io.   Contribute with issues, pull requests, and comments. Copy, review, and use the published specification for programming whatever genealogical software you want.  Make pull requests for changes to these web pages.
+    title: "GitHub Public Repository"
+    excerpt: "Join the public repository and contribute with issues, pull requests, and comments. Copy, review, and use the published specification for programming whatever genealogical software you want."
     url: "http://github.com/familysearch/GEDCOM"
-    btn_label: "GEDCOM Specification Repository"
-    
-      url: "http://github.com/familysearch/GEDCOM.io"
-    btn_label: "GEDCOM.io Web Pages Repository"
+    btn_label: "GitHub Repository"
 ---
 
 {% include feature_row %}


### PR DESCRIPTION
Reverts FamilySearch/GEDCOM.io#37 because it mis-formatted some metadata and broke the home page