### PR TITLE
Make NAME and NAME.TRAN include all name pieces

### DIFF
--- a/testfiles/gedcom70/maximal70.ged
+++ b/testfiles/gedcom70/maximal70.ged
@@ -228,13 +228,13 @@
 1 CHIL @I1@
 0 @I1@ INDI
 1 RESN CONFIDENTIAL, LOCKED
-1 NAME Lt. Cmndr. Joseph /Allen/ jr.
+1 NAME Lt. Cmndr. Joseph "John" /de Allen/ jr.
 2 TYPE OTHER
 3 PHRASE Name type phrase
 2 NPFX Lt. Cmndr.
 2 GIVN Joseph
 2 NICK John
-2 SPFX spfx
+2 SPFX de
 2 SURN Allen
 2 NSFX jr.
 2 TRAN John /Doe/

--- a/testfiles/gedcom70/maximal70.ged
+++ b/testfiles/gedcom70/maximal70.ged
@@ -237,7 +237,7 @@
 2 SPFX de
 2 SURN Allen
 2 NSFX jr.
-2 TRAN John /Doe/
+2 TRAN npfx John /spfx Doe/ nsfx
 3 LANG en-GB
 3 NPFX npfx
 3 GIVN John


### PR DESCRIPTION
In https://github.com/FamilySearch/GEDCOM/issues/134 Luther writes:

> The current spec says
>
>> The PERSONAL_NAME_PIECES are provided optionally for systems that cannot
>> operate effectively with less structured information. The Personal Name
>> payload shall be seen as the primary name representation, with name
>> pieces as optional auxiliary information.
>
> One reading of this is that the NICK cannot have data that is absent
> from and cannot be derived from the NAME. If that is the case, then the
> NICK cannot be omitted from the NAME

Thus, follow that rule for all name pieces in the maximal GEDCOM file.

Signed-off-by: Dave Thaler <dthaler@armidalesoftware.com>