### PR TITLE
Don't have level 2 DATE and STAT in the same lds ordinance event

### DIFF
--- a/testfiles/gedcom70/maximal70.ged
+++ b/testfiles/gedcom70/maximal70.ged
@@ -5,7 +5,7 @@
 2 TAG _SKYPEID http://xmlns.com/foaf/0.1/skypeID
 2 TAG _JABBERID http://xmlns.com/foaf/0.1/jabberID
 1 SOUR https://gedcom.io/
-2 VERS 0.2
+2 VERS 0.3
 2 NAME GEDCOM Steering Committee
 2 CORP FamilySearch
 3 ADDR Family History Department, 15 East South Temple Street, Salt Lake City, UT 84150 USA
@@ -29,7 +29,7 @@
 4 TIME 8:38
 3 COPR copyright statement
 1 DEST https://gedcom.io/
-1 DATE 22 MAY 2022
+1 DATE 10 JUN 2022
 2 TIME 15:43:20.48Z
 1 SUBM @U1@
 1 COPR another copyright statement
@@ -398,24 +398,29 @@
 1 BAPL
 2 STAT BIC
 3 DATE 27 MAR 2022
+1 BAPL
 2 DATE 27 MAR 2022
 1 CONL
 2 STAT INFANT
 3 DATE 27 MAR 2022
+1 CONL
 2 DATE 27 MAR 2022
 1 ENDL
 2 STAT CHILD
 3 DATE 27 MAR 2022
+1 ENDL
 2 DATE 27 MAR 2022
 1 INIL
 2 STAT EXCLUDED
 3 DATE 27 MAR 2022
+1 INIL
 2 DATE 27 MAR 2022
 1 SLGC
 2 DATE 27 MAR 2022
 3 TIME 15:47
 3 PHRASE Afternoon
 2 TEMP SLAKE
+1 SLGC
 2 PLAC Place
 2 STAT COMPLETED
 3 DATE 27 MAR 2022


### PR DESCRIPTION
Per discussion on https://github.com/FamilySearch/GEDCOM/issues/157 it is not worth testing whether this odd case is preserved, but is worth testing whether multiple events are preserved.

Signed-off-by: Dave Thaler <dthaler@armidalesoftware.com>