### PR TITLE
Fix spelling of romaji

### DIFF
--- a/_pages/migrate.md
+++ b/_pages/migrate.md
@@ -16,7 +16,7 @@ Thus, this 5.5.1:
 ```
 1 NAME /橘/ 逸勢
 2 ROMN /Tachibana/ no Hayanari
-3 TYPE romanji
+3 TYPE romaji
 2 FONE /たちばな/ の はやなり
 3 TYPE kana
 ```
@@ -48,7 +48,7 @@ The full mapping of 5.5.1 types is is
     
     Note: pinyin could be either `zh-Latn-pinyin` or `bo-Latn-pinyin`; thus, from 5.5.1 alone we can't deduce the language, only the script and variant, hence the `und` (undetermined) language above.
 
-- `ROMN`.`TYPE romanji` = `TRAN`.`LANG ja-Latn`
+- `ROMN`.`TYPE romaji` = `TRAN`.`LANG ja-Latn`
 
 - `ROMN`.`TYPE wadegiles` = `TRAN`.`LANG zh-Latn-wadegile`
 

--- a/_pages/tag-def/PLAC-TRAN.md
+++ b/_pages/tag-def/PLAC-TRAN.md
@@ -22,7 +22,7 @@ descriptions:
     A type of TRAN substructure specific to places. Each PLAC.TRAN must have a
     LANG substructure. See also PLAC.
     
-    The following presents a place in Japanese with a romanji transliteration
+    The following presents a place in Japanese with a romaji transliteration
     and English translation
     
         2 PLAC 千代田, 東京, 日本


### PR DESCRIPTION
"romanji" is incorrect, the word is [romaji](https://en.wikipedia.org/wiki/Romanization_of_Japanese).

Signed-off-by: Dave Thaler <dthaler@armidalesoftware.com>