### PR TITLE
sort YAML documentation by key

### DIFF
--- a/_pages/yaml-file-format.md
+++ b/_pages/yaml-file-format.md
@@ -106,15 +106,6 @@ The following keys may appear in a YAML file.
 Their names may be changed a YAML file with a `lang` other than `en`.
 
 -   <table><tbody>
-    <tr><th>Key</th><td><code>enumeration set</code></td></tr>
-    <tr><th>Type</th><td>URI</td></tr>
-    <tr><th>Required by</th><td><code>type: structure</code> with <code>payload</code> either <code>g7:type-Enum</code> or <code>g7:type-List#Enum</code></td></tr>
-    <tr><th>Allowed by</th><td>—</td></tr>
-    </tbody></table>
-    
-    The URI of the set of enumeration values permitted in the payload of this structure.
-
--   <table><tbody>
     <tr><th>Key</th><td><code>calendars</code></td></tr>
     <tr><th>Type</th><td><code>seq</code> of URI</td></tr>
     <tr><th>Required by</th><td><code>type: month</code></td></tr>
@@ -126,17 +117,6 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     The list may be incomplete, as a new calendar might be defined that uses an existing month.
 
 -   <table><tbody>
-    <tr><th>Key</th><td><code>specification</code></td></tr>
-    <tr><th>Type</th><td><code>seq</code> of <code>str</code></td></tr>
-    <tr><th>Required by</th><td>all except <code>type: enumeration set</code></td></tr>
-    <tr><th>Allowed by</th><td>all</td></tr>
-    </tbody></table>
-    
-    A list (in no particular order) of descriptions of the concept the YAML document is defining.
-    
-    The specification are generally programmer-centric; for user-centric text, see `label` and `help text`
-
--   <table><tbody>
     <tr><th>Key</th><td><code>documentation</code></td></tr>
     <tr><th>Type</th><td><code>seq</code> of URI</td></tr>
     <tr><th>Required by</th><td>—</td></tr>
@@ -144,6 +124,15 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     </tbody></table>
 
     One or more external URLs where additional documentation can be found. If there is no such URL, this entry should be omitted.
+
+-   <table><tbody>
+    <tr><th>Key</th><td><code>enumeration set</code></td></tr>
+    <tr><th>Type</th><td>URI</td></tr>
+    <tr><th>Required by</th><td><code>type: structure</code> with <code>payload</code> either <code>g7:type-Enum</code> or <code>g7:type-List#Enum</code></td></tr>
+    <tr><th>Allowed by</th><td>—</td></tr>
+    </tbody></table>
+    
+    The URI of the set of enumeration values permitted in the payload of this structure.
 
 -   <table><tbody>
     <tr><th>Key</th><td><code>enumeration values</code></td></tr>
@@ -235,6 +224,17 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     - The URI of a datatype, meaning a payload of this type is required
     - A string of the form `@<`URI`>@`, meaning the payload is a pointer to a structure whose type is given by the URI.
     
+-   <table><tbody>
+    <tr><th>Key</th><td><code>specification</code></td></tr>
+    <tr><th>Type</th><td><code>seq</code> of <code>str</code></td></tr>
+    <tr><th>Required by</th><td>all except <code>type: enumeration set</code></td></tr>
+    <tr><th>Allowed by</th><td>all</td></tr>
+    </tbody></table>
+    
+    A list (in no particular order) of descriptions of the concept the YAML document is defining.
+    
+    The specification are generally programmer-centric; for user-centric text, see `label` and `help text`
+
 -   <table><tbody>
     <tr><th>Key</th><td><code>standard tag</code></td></tr>
     <tr><th>Type</th><td><code>stdTag</code></td></tr>


### PR DESCRIPTION
The YAML documentation had keys mostly sorted alphabetically, with two exceptions. This PR fixes those exceptions