### PR TITLE
Add YAML key for overlapping meanings

### DIFF
--- a/_pages/yaml-file-format.md
+++ b/_pages/yaml-file-format.md
@@ -106,15 +106,6 @@ The following keys may appear in a YAML file.
 Their names may be changed a YAML file with a `lang` other than `en`.
 
 -   <table><tbody>
-    <tr><th>Key</th><td><code>enumeration set</code></td></tr>
-    <tr><th>Type</th><td>URI</td></tr>
-    <tr><th>Required by</th><td><code>type: structure</code> with <code>payload</code> either <code>g7:type-Enum</code> or <code>g7:type-List#Enum</code></td></tr>
-    <tr><th>Allowed by</th><td>—</td></tr>
-    </tbody></table>
-    
-    The URI of the set of enumeration values permitted in the payload of this structure.
-
--   <table><tbody>
     <tr><th>Key</th><td><code>calendars</code></td></tr>
     <tr><th>Type</th><td><code>seq</code> of URI</td></tr>
     <tr><th>Required by</th><td><code>type: month</code></td></tr>
@@ -126,17 +117,6 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     The list may be incomplete, as a new calendar might be defined that uses an existing month.
 
 -   <table><tbody>
-    <tr><th>Key</th><td><code>specification</code></td></tr>
-    <tr><th>Type</th><td><code>seq</code> of <code>str</code></td></tr>
-    <tr><th>Required by</th><td>all except <code>type: enumeration set</code></td></tr>
-    <tr><th>Allowed by</th><td>all</td></tr>
-    </tbody></table>
-    
-    A list (in no particular order) of descriptions of the concept the YAML document is defining.
-    
-    The specification are generally programmer-centric; for user-centric text, see `label` and `help text`
-
--   <table><tbody>
     <tr><th>Key</th><td><code>documentation</code></td></tr>
     <tr><th>Type</th><td><code>seq</code> of URI</td></tr>
     <tr><th>Required by</th><td>—</td></tr>
@@ -144,6 +124,15 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     </tbody></table>
 
     One or more external URLs where additional documentation can be found. If there is no such URL, this entry should be omitted.
+
+-   <table><tbody>
+    <tr><th>Key</th><td><code>enumeration set</code></td></tr>
+    <tr><th>Type</th><td>URI</td></tr>
+    <tr><th>Required by</th><td><code>type: structure</code> with <code>payload</code> either <code>g7:type-Enum</code> or <code>g7:type-List#Enum</code></td></tr>
+    <tr><th>Allowed by</th><td>—</td></tr>
+    </tbody></table>
+    
+    The URI of the set of enumeration values permitted in the payload of this structure.
 
 -   <table><tbody>
     <tr><th>Key</th><td><code>enumeration values</code></td></tr>
@@ -235,6 +224,17 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     - The URI of a datatype, meaning a payload of this type is required
     - A string of the form `@<`URI`>@`, meaning the payload is a pointer to a structure whose type is given by the URI.
     
+-   <table><tbody>
+    <tr><th>Key</th><td><code>specification</code></td></tr>
+    <tr><th>Type</th><td><code>seq</code> of <code>str</code></td></tr>
+    <tr><th>Required by</th><td>all except <code>type: enumeration set</code></td></tr>
+    <tr><th>Allowed by</th><td>all</td></tr>
+    </tbody></table>
+    
+    A list (in no particular order) of descriptions of the concept the YAML document is defining.
+    
+    The specification are generally programmer-centric; for user-centric text, see `label` and `help text`
+
 -   <table><tbody>
     <tr><th>Key</th><td><code>standard tag</code></td></tr>
     <tr><th>Type</th><td><code>stdTag</code></td></tr>

--- a/_pages/yaml-file-format.md
+++ b/_pages/yaml-file-format.md
@@ -267,6 +267,24 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     If `superstructures` is an empty `map`, then the structure is a record and must not appear in any other structure's `substructures`.
 
 -   <table><tbody>
+    <tr><th>Key</th><td><code>subsumes</code></td></tr>
+    <tr><th>Type</th><td><code>seq</code> of URI</td></tr>
+    <tr><th>Required by</th><td>—</td></tr>
+    <tr><th>Allowed by</th><td>all</td></tr>
+    </tbody></table>
+
+    A list of URIs that can be replaced by this URI without any loss of information or change of meaning.
+    This does not simply mean they *can* express the same thing,
+    but rather that they express the same thing *in the same way*,
+    i.e. with no change in payloads or substructures.
+    
+    One example use-case is an extension becoming standard and being given a URI with a gedcom.io host, in which case both the extension URI's YAML file and the standard URI's YAML file can list the other as URIs it `subsumes`.
+    
+    Another example use-case is an extension that adds to another extension,
+    for example by allowing a larger set of payloads or more substructures.
+    In this case the more permissive/larger extension would say it `subsumes` the more strict/smaller extension, but not the other way around.
+
+-   <table><tbody>
     <tr><th>Key</th><td><code>value of</code></td></tr>
     <tr><th>Type</th><td><code>seq</code> of URI</td></tr>
     <tr><th>Required by</th><td><code>type: enumeration</code></td></tr>

--- a/_pages/yaml-file-format.md
+++ b/_pages/yaml-file-format.md
@@ -257,7 +257,7 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     A list of URIs that can be replaced by this URI without any loss of information or change of meaning.
     This does not simply mean they *can* express the same thing,
     but rather that they express the same thing *in the same way*,
-    i.e. with no change in payloads or substructures.
+    i.e., with no change in payloads or substructures.
     
     One example use-case is an extension becoming standard and being given a URI with a gedcom.io host, in which case both the extension URI's YAML file and the standard URI's YAML file can list the other as URIs it `subsumes`.
     

--- a/_pages/yaml-file-format.md
+++ b/_pages/yaml-file-format.md
@@ -248,6 +248,24 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     The standard tag of this concept, as given in an official GEDCOM standard document.
 
 -   <table><tbody>
+    <tr><th>Key</th><td><code>subsumes</code></td></tr>
+    <tr><th>Type</th><td><code>seq</code> of URI</td></tr>
+    <tr><th>Required by</th><td>—</td></tr>
+    <tr><th>Allowed by</th><td>all</td></tr>
+    </tbody></table>
+
+    A list of URIs that can be replaced by this URI without any loss of information or change of meaning.
+    This does not simply mean they *can* express the same thing,
+    but rather that they express the same thing *in the same way*,
+    i.e. with no change in payloads or substructures.
+    
+    One example use-case is an extension becoming standard and being given a URI with a gedcom.io host, in which case both the extension URI's YAML file and the standard URI's YAML file can list the other as URIs it `subsumes`.
+    
+    Another example use-case is an extension that adds to another extension,
+    for example by allowing a larger set of payloads or more substructures.
+    In this case the more permissive/larger extension would say it `subsumes` the more strict/smaller extension, but not the other way around.
+
+-   <table><tbody>
     <tr><th>Key</th><td><code>substructure</code> and <code>superstucture</code></td></tr>
     <tr><th>Type</th><td><code>map</code> with URI keys and Cardinality Marker values</td></tr>
     <tr><th>Required by</th><td><code>type: structure</code></td></tr>
@@ -265,24 +283,6 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     If the relationship is listed in both a `substructures` entry and a `superstructures` entry, the two must have the same cardinality.
     
     If `superstructures` is an empty `map`, then the structure is a record and must not appear in any other structure's `substructures`.
-
--   <table><tbody>
-    <tr><th>Key</th><td><code>subsumes</code></td></tr>
-    <tr><th>Type</th><td><code>seq</code> of URI</td></tr>
-    <tr><th>Required by</th><td>—</td></tr>
-    <tr><th>Allowed by</th><td>all</td></tr>
-    </tbody></table>
-
-    A list of URIs that can be replaced by this URI without any loss of information or change of meaning.
-    This does not simply mean they *can* express the same thing,
-    but rather that they express the same thing *in the same way*,
-    i.e. with no change in payloads or substructures.
-    
-    One example use-case is an extension becoming standard and being given a URI with a gedcom.io host, in which case both the extension URI's YAML file and the standard URI's YAML file can list the other as URIs it `subsumes`.
-    
-    Another example use-case is an extension that adds to another extension,
-    for example by allowing a larger set of payloads or more substructures.
-    In this case the more permissive/larger extension would say it `subsumes` the more strict/smaller extension, but not the other way around.
 
 -   <table><tbody>
     <tr><th>Key</th><td><code>value of</code></td></tr>


### PR DESCRIPTION
Adds a `subsumes` key with list-of-URI value for indicating that the given concept is the same as or a superset of another concept.

Depends on #98 (I couldn't get the order to work our right otherwise) so that should be merged first.