### PR TITLE
Describe and link to YAML registry

### DIFF
--- a/_pages/tools.md
+++ b/_pages/tools.md
@@ -54,7 +54,7 @@ The following files are provided for testing.
 
 ## Extension Registry
 
-As part of publishing each version of the FamilySearch GEDCOM 7 specification, a set of YAML files are generated describing each structure type, enumeration set, enumeration value, calendar, and month.
+As part of publishing each version of the [FamilySearch GEDCOM 7 specification](https://gedcom.io/specs/#familysearch-gedcom-version-7), a set of YAML files are generated describing each structure type, enumeration set, enumeration value, calendar, and month.
 The format is [documented](/terms/format)
 and served at the URIs documented in the specification (e.g. <https://gedcom.io/terms/v7/HEAD>).
 

--- a/_pages/tools.md
+++ b/_pages/tools.md
@@ -56,7 +56,7 @@ The following files are provided for testing.
 
 As part of publishing each version of the [FamilySearch GEDCOM 7 specification](https://gedcom.io/specs/#familysearch-gedcom-version-7), a set of YAML files are generated describing each structure type, enumeration set, enumeration value, calendar, and month.
 The format is [documented](/terms/format)
-and served at the URIs documented in the specification (e.g. <https://gedcom.io/terms/v7/HEAD>).
+and served at the URIs documented in the specification (e.g., <https://gedcom.io/terms/v7/HEAD>).
 
 The full set of YAML files, together with some synthesis information such as parsing metadata and lists of all structure types, can be found in the [GEDCOM-registries github repository](https://github.com/familysearch/gedcom-registries).
 The GEDCOM-registries repository also hosts YAML files for extensions to the specification,

--- a/_pages/tools.md
+++ b/_pages/tools.md
@@ -52,6 +52,16 @@ The following files are provided for testing.
 | [spaces.ged](/testfiles/gedcom70/spaces.ged) | This file contains empty DATE and EVEN payloads, with and without spaces. |
 | [voidptr.ged](/testfiles/gedcom70/voidptr.ged) | This file contains several @VOID@ references. |
 
+## Extension Registry
+
+As part of publishing each version of the FamilySearch GEDCOM 7 specification, a set of YAML files are generated describing each structure type, enumeration set, enumeration value, calendar, and month.
+The format is [documented](/terms/format)
+and served at the URIs documented in the specification (e.g. <https://gedcom.io/terms/v7/HEAD>).
+
+The full set of YAML files, together with some synthesis information such as parsing metadata and lists of all structure types, can be found in the [GEDCOM-registries github repository](https://github.com/familysearch/gedcom-registries).
+The GEDCOM-registries repository also hosts YAML files for extensions to the specification,
+facilitating interoperability beyond the official specification.
+
 ## Other Development Tools
 
 Other development, conversions tools and sample files will be posted here as they become available.


### PR DESCRIPTION
We already had a link in the navigation sidebar, but it went nowhere; this adds the section it references.