### PR TITLE
Add `epochs` and `subsumes` to yaml-schema.yaml

### DIFF
--- a/yaml-schema.yaml
+++ b/yaml-schema.yaml
@@ -52,6 +52,11 @@ properties:
     "$ref": "#/definitions/uris"
   months:
     "$ref": "#/definitions/uris"
+  epochs:
+    type: array
+    items:
+      type: string
+      pattern: "^(BCE|_[A-Z0-9_]+)$"
   value of:
     "$ref": "#/definitions/uris"
   specification:
@@ -66,6 +71,8 @@ properties:
     "$ref": "#/definitions/card"
   superstructures:
     "$ref": "#/definitions/card"
+  subsumes:
+    "$ref": "#/definitions/uris"
   
 additionalProperties: false
 
@@ -80,7 +87,7 @@ allOf:
   - if: {properties: {type: {const: enumeration}}}
     then: {required: [specification, value of]}
   - if: {properties: {type: {const: calendar}}}
-    then: {required: [specification, months]}
+    then: {required: [specification, months, epochs]}
   - if: {properties: {type: {const: month}}}
     then: {required: [calendars]}
   - if: {properties: {type: {const: data type}}}


### PR DESCRIPTION
See also https://github.com/FamilySearch/GEDCOM-registries/pull/7 which adds `subsumes` to the copy of this file in that repo

Note: I had added epochs to the copy of this file in https://github.com/familysearch/gedcom-registries when we first added it, but forgot to update this it in this repository. We should probably reduce the number of copies of yaml-schema.yaml that we need to maintain to just one.