### PR TITLE
YAML format should allow tracking applications using extensions

### DIFF
--- a/_pages/yaml-file-format.md
+++ b/_pages/yaml-file-format.md
@@ -301,7 +301,6 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     <tr><th>Allowed by</th><td>all</td></tr>
     </tbody></table>
 
-    \* Required instead of allowed if no `standard tag` is provided
 
     A list of [`g7:HEAD-SOUR`](https://github.com/FamilySearch/GEDCOM-registries/blob/main/structure/standard/HEAD-SOUR.yaml)
     values of applications known to use an extension tag for this concept.

--- a/_pages/yaml-file-format.md
+++ b/_pages/yaml-file-format.md
@@ -295,6 +295,18 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     If `superstructures` is an empty `map`, then the structure is a record and must not appear in any other structure's `substructures`.
 
 -   <table><tbody>
+    <tr><th>Key</th><td><code>used by</code></td></tr>
+    <tr><th>Type</th><td><code>str</code></td></tr>
+    <tr><th>Required by</th><td>—</td></tr>
+    <tr><th>Allowed by</th><td>all</td></tr>
+    </tbody></table>
+
+    \* Required instead of allowed if no `standard tag` is provided
+
+    A list of [`g7:HEAD-SOUR`](https://github.com/FamilySearch/GEDCOM-registries/blob/main/structure/standard/HEAD-SOUR.yaml)
+    values of applications known to use an extension tag for this concept.
+
+-   <table><tbody>
     <tr><th>Key</th><td><code>value of</code></td></tr>
     <tr><th>Type</th><td><code>seq</code> of URI</td></tr>
     <tr><th>Required by</th><td><code>type: enumeration</code></td></tr>

--- a/_pages/yaml-file-format.md
+++ b/_pages/yaml-file-format.md
@@ -296,7 +296,7 @@ Their names may be changed a YAML file with a `lang` other than `en`.
 
 -   <table><tbody>
     <tr><th>Key</th><td><code>used by</code></td></tr>
-    <tr><th>Type</th><td><code>str</code></td></tr>
+    <tr><th>Type</th><td><code>seq</code> of <code>str</code></td></tr>
     <tr><th>Required by</th><td>—</td></tr>
     <tr><th>Allowed by</th><td>all</td></tr>
     </tbody></table>


### PR DESCRIPTION
https://github.com/familysearch/GEDCOM-registries?tab=readme-ov-file#registering-extensions says that "once an extension meets the Valuable, Absent, and Used criteria then a standard tag/URI can be added...".

https://github.com/FamilySearch/GEDCOM/tree/main/attribute-event-requests tracks what things are used by apps, but it's only for attributes and events, not other extensions.

This PR proposes the ability to track "used by" in any YAML file that describes an extension.