### PR TITLE
Fix GEDCOM branch name for v7.1

### DIFF
--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -33,7 +33,7 @@ jobs:
           - BRANCH: 'main'
             GEDCOM_BRANCH: 'release'
           - BRANCH: 'next-minor'
-            GEDCOM_BRANCH: 'next-minor'
+            GEDCOM_BRANCH: 'v7.1'
           - BRANCH: 'next-patch'
             GEDCOM_BRANCH: 'main'
 


### PR DESCRIPTION
It used to be next-minor and is now v7.1