### PR TITLE
Group dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
@@ -17,3 +21,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Currently dependabot will generate a pull request per dependency being updated.  This change will cause all ruby dependencies to be updated in one pull request, and the same for all github action dependencies, to reduce the number of dependabot PRs.