### PR TITLE
Add HEAD.NOTE to many example files

### DIFF
--- a/testfiles/gedcom70/age.ged
+++ b/testfiles/gedcom70/age.ged
@@ -1,6 +1,7 @@
 ﻿0 HEAD
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
 0 @I1@ INDI
 1 NOTE There are many ways to express an age of "zero".
 1 CHR

--- a/testfiles/gedcom70/escapes.ged
+++ b/testfiles/gedcom70/escapes.ged
@@ -1,6 +1,7 @@
 ﻿0 HEAD
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
 0 @I1@ INDI
 1 NAME John /Doe/
 1 NOTE me@example.com is an example email address.

--- a/testfiles/gedcom70/extension-record.ged
+++ b/testfiles/gedcom70/extension-record.ged
@@ -1,6 +1,7 @@
 ﻿0 HEAD
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
 1 SOUR Test
 0 @I1@ INDI
 1 NAME John /Doe/

--- a/testfiles/gedcom70/extensions.ged
+++ b/testfiles/gedcom70/extensions.ged
@@ -16,7 +16,9 @@
 2 TAG _PHRASE https://gedcom.io/terms/v7/PHRASE
 2 TAG _PARTY http://example.com/party-participation
 2 TAG _PARTY http://example.com/party
-1 NOTE This file contains the following extension-related content:
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
+2 CONT
+2 CONT This file contains the following extension-related content:
 2 CONT Standard record with an extTag           0 @U1@ _USER
 2 CONT Standard substructure                    1 NAME Aliased record
 2 CONT Standard structure with an extTag        1 _CREATOR @U1@

--- a/testfiles/gedcom70/filename-1.ged
+++ b/testfiles/gedcom70/filename-1.ged
@@ -1,6 +1,7 @@
 ﻿0 HEAD
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
 0 @1@ OBJE
 1 NOTE Traditional file URI for a local file with an empty authority, per RFC 8089.
 1 FILE file:///unix/absolute

--- a/testfiles/gedcom70/lang.ged
+++ b/testfiles/gedcom70/lang.ged
@@ -1,8 +1,9 @@
 ﻿0 HEAD
-1 SOUR TEST_FILES
-1 SUBM @1@
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
+1 SOUR TEST_FILES
+1 SUBM @1@
 1 LANG af
 1 SCHMA
 2 TAG _PHRASE https://gedcom.io/terms/v7/PHRASE

--- a/testfiles/gedcom70/long-url.ged
+++ b/testfiles/gedcom70/long-url.ged
@@ -1,6 +1,7 @@
 0 HEAD
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
 1 SUBM @S1@
 0 @S1@ SUBM
 1 NAME John Doe

--- a/testfiles/gedcom70/maximal70-lds.ged
+++ b/testfiles/gedcom70/maximal70-lds.ged
@@ -1,6 +1,7 @@
 ﻿0 HEAD
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
 0 @F1@ FAM
 1 MARR Y
 2 DATE 27 MAR 2022

--- a/testfiles/gedcom70/maximal70-memories1.ged
+++ b/testfiles/gedcom70/maximal70-memories1.ged
@@ -1,6 +1,7 @@
 ﻿0 HEAD
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
 0 @F1@ FAM
 1 MARR Y
 2 DATE 27 MAR 2022

--- a/testfiles/gedcom70/maximal70-memories2.ged
+++ b/testfiles/gedcom70/maximal70-memories2.ged
@@ -1,6 +1,7 @@
 ﻿0 HEAD
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
 0 @F1@ FAM
 1 MARR Y
 2 DATE 27 MAR 2022

--- a/testfiles/gedcom70/maximal70-tree1.ged
+++ b/testfiles/gedcom70/maximal70-tree1.ged
@@ -1,6 +1,7 @@
 ﻿0 HEAD
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
 0 @F1@ FAM
 1 MARR Y
 2 DATE 27 MAR 2022

--- a/testfiles/gedcom70/maximal70-tree2.ged
+++ b/testfiles/gedcom70/maximal70-tree2.ged
@@ -1,6 +1,7 @@
 ﻿0 HEAD
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
 0 @F1@ FAM
 1 NCHI 2
 2 TYPE Type of children

--- a/testfiles/gedcom70/maximal70.ged
+++ b/testfiles/gedcom70/maximal70.ged
@@ -1,6 +1,7 @@
 ﻿0 HEAD
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
 1 SCHMA
 2 TAG _SKYPEID http://xmlns.com/foaf/0.1/skypeID
 2 TAG _JABBERID http://xmlns.com/foaf/0.1/jabberID

--- a/testfiles/gedcom70/xref.ged
+++ b/testfiles/gedcom70/xref.ged
@@ -1,6 +1,7 @@
 ﻿0 HEAD
 1 GEDC
 2 VERS 7.0
+1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
 0 INDI
 1 NOTE This individual has no cross-reference identifier.
 0 @I1@ INDI


### PR DESCRIPTION
As noted in https://github.com/FamilySearch/GEDCOM/issues/561 many of the example files don't make any sense: they contain more-or-less random payloads of the right type for each structure. This adds the following to the header of each such file:

```ged
1 NOTE This file is intended to provide coverage of parts of the specification and does not contain meaningful historical or genealogical data.
```

Note that some example files are made-up data but at lease somewhat internally consistent; for example, `same-sex-marriage.ged` has internally-consistent (but made-up) names and relationships. This does not add that note to those files.

This commit also does not change the .gdz files. I can't recall if those are automatically updated or if I need to update them manually.