### PR TITLE
Minor fixes to get rid of some yamllint warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 # For documentation on the format of this file, see
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+---
 version: 2
 updates:
 

--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -5,6 +5,7 @@
 #
 # For documentation on the syntax of this file, see
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+---
 name: Update
 
 on:

--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -3,6 +3,7 @@
 #
 # For documentation on the syntax of this file, see
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+---
 name: Validate-YAML
 
 on:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,7 +1,9 @@
 # Configuration file for yamllint.  For documentation, see
 # https://yamllint.readthedocs.io/en/stable/configuration.html
-
+---
 extends: default
 
 rules:
   line-length: disable
+  truthy:
+    check-keys: false

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -7,3 +7,5 @@ rules:
   line-length: disable
   truthy:
     check-keys: false
+  comments:
+    min-spaces-from-content: 1

--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -1,5 +1,5 @@
 # Develop override settings
-
+---
 url: http://127.0.0.1:4000
 remote_theme: false
 theme: minimal-mistakes-jekyll

--- a/_config.yml
+++ b/_config.yml
@@ -17,10 +17,10 @@
 title: FamilySearch GEDCOM
 subtitle: Genealogical Data Communication
 email: your-email@example.com
-description: >- # this means to ignore newlines until "baseurl:"
+description: >-  # this means to ignore newlines until "baseurl:"
   - The official website for the GEDCOM specification used for storing and sharing genealogical information.
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: ""  # the subpath of your site, e.g. /blog
+url: ""  # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: FamilySearch
 github_username: FamilySearch
 repository: "FamilySearch/GEDCOM.io"
@@ -40,7 +40,7 @@ plugins:
   - jekyll-include-cache
 
 permalink: /:year/:month/:day/:title
-# paginate: 5 # amount of posts to show
+# paginate: 5  # amount of posts to show
 # paginate_path: /page:num/
 timezone: America/Denver
 
@@ -49,7 +49,7 @@ include:
 
 # Analytics
 analytics:
-  provider: "custom" # Put your analytics code in /_includes/analytics-providers/custom.html
+  provider: "custom"  # Put your analytics code in /_includes/analytics-providers/custom.html
 
 collections:
   faqs:

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
+---
 title: FamilySearch GEDCOM
 subtitle: Genealogical Data Communication
 email: your-email@example.com

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,3 +1,4 @@
+---
 main:
   - title: "About"
     url: /about/

--- a/yaml-schema.yaml
+++ b/yaml-schema.yaml
@@ -1,3 +1,4 @@
+---
 "$schema": "https://json-schema.org/draft/2020-12"
 
 type: object


### PR DESCRIPTION
This PR fixes warnings generated during github CI/CD in the validate-yaml workflow:

* Get rid of yamllint warnings about missing "---"
* Get rid of "truthy value should be one of [false, true]" warnings
* Get rid of "too few spaces before comment" warnings