### PR TITLE
remove BOM from minimal.ged

### DIFF
--- a/testfiles/gedcom70/minimal70.ged
+++ b/testfiles/gedcom70/minimal70.ged
@@ -1,4 +1,4 @@
-﻿0 HEAD
+0 HEAD
 1 GEDC
 2 VERS 7.0
 0 TRLR


### PR DESCRIPTION
Resolve #216 by removing the byte order mark from minimal.ged