### PR TITLE
Add fragment and change controller to yaml-schema.yaml

### DIFF
--- a/yaml-schema.yaml
+++ b/yaml-schema.yaml
@@ -76,6 +76,10 @@ properties:
     "$ref": "#/definitions/uris"
   contact:
     type: string
+  change controller:
+    type: string
+  fragment:
+    type: string
 
 additionalProperties: false
 


### PR DESCRIPTION
Adds `fragment` and `change controller` as top-level properties in the YAML schema. They are never required, and the YAML schema does not currently enforce the "allowed by" for properties so I don't enforce it for "fragment" either.