### PR TITLE
Add field size errata for 5.5.1

### DIFF
--- a/_pages/gedcom551-errata.md
+++ b/_pages/gedcom551-errata.md
@@ -26,7 +26,7 @@ The following is the current list of errata for [the GEDCOM Standard, Release 5.
 | 59 |  9 | PLACE_PHONETIC_VARIATION | the same form as&nbsp; was the place name | the same form as was the place name | Remove extra space before "was" |
 | 59 | 11 | PLACE_PHONETIC_VARIATION | for example if hiragana was used to provide a reading of a a | for example if hiragana was used to provide a reading of a | Remove duplicate "a" |
 | 60 | 19 | RESTRICTION_NOTICE | {Size=6:7} | {Size=6:12} | Maximum size is 12 to accommodate "confidential" |
-| 61 |  5 | ROLE_DESCRIPTOR | {Size=1:25} | {Size=1:13} | Only used within ROLE_IN_EVENT which has max size 15 |
+| 61 |  9 | ROLE_IN_EVENT | {Size=1:15} | {Size=1:27} | Accommodate a ROLE_DESCRIPTOR of length 25 |
 | 62 |  8 | SOURCE_DESCRIPTIVE_TITLE | For An _unpublished_ work such as: | For an _unpublished_ work such as: | Lower case "an" |
 | 62 | 14 | SOURCE_FILED_BY_ENTRY | {Size= 1:60} | {Size=1:60} | Remove space |
 | 62 | 22 | SOURCE_MEDIA_TYPE | {Size=1:15} | {Size=3:10) | All alternatives are within size range 3 to 10 |

--- a/_pages/gedcom551-errata.md
+++ b/_pages/gedcom551-errata.md
@@ -17,11 +17,19 @@ The following is the current list of errata for [the GEDCOM Standard, Release 5.
 | 37 |  6 | MULTIMEDIA_LINK |            | [ | Add open bracket before first line of MULTIMEDIA_LINK |
 | 37 | 12 | MULTIMEDIA_LINK |            | ] | Add close bracket after last line of MULTIMEDIA_LINK |
 | 37 |  8 | MULTIMEDIA_LINK | n **OBJE** | n **OBJE**     {1:1} | Add cardinality |
+| 54 |  4 | MULTIMEDIA_FORMAT | {Size=3:4} | {Size=3:3} | Maximum size is 3 since all values are size 3 |
+| 56 | 15 | NAME_TYPE | {Size=5:30} | {Size=3:30} | Minimum size is 3 due to accommodate "aka" |
+| 57 | 33 | PHONETIC_TYPE | {Size=5:30} | {Size=4:30} | Minimum size is 4 to accommodate "kana" |
 | 58 |  2 | PHONETIC_TYPE | \<user define\> | \<user defined\> | Change "define" to "defined" |
+| 58 | 21 | PLACE_LATITUDE | {Size=5:8} | {Size=5:10} | Maximum size is 10 to accommodate the example in line 25 |
+| 58 | 32 | PLACE_LONGITUDE | {Size=5:8} | {Size=5:11} | Maximum size is 11 to accommodate the example in line 35 |
 | 59 |  9 | PLACE_PHONETIC_VARIATION | the same form as&nbsp; was the place name | the same form as was the place name | Remove extra space before "was" |
 | 59 | 11 | PLACE_PHONETIC_VARIATION | for example if hiragana was used to provide a reading of a a | for example if hiragana was used to provide a reading of a | Remove duplicate "a" |
+| 60 | 19 | RESTRICTION_NOTICE | {Size=6:7} | {Size=6:12} | Maximum size is 12 to accommodate "confidential" |
+| 61 |  5 | ROLE_DESCRIPTOR | {Size=1:25} | {Size=1:13} | Only used within ROLE_IN_EVENT which has max size 15 |
 | 62 |  8 | SOURCE_DESCRIPTIVE_TITLE | For An _unpublished_ work such as: | For an _unpublished_ work such as: | Lower case "an" |
-| 62 | 14 | SOURCE_FILED_BY_ENTRY |  {Size= 1:60} | {Size=1:60} | Remove space |
+| 62 | 14 | SOURCE_FILED_BY_ENTRY | {Size= 1:60} | {Size=1:60} | Remove space |
+| 62 | 22 | SOURCE_MEDIA_TYPE | {Size=1:15} | {Size=3:10) | All alternatives are within size range 3 to 10 |
 | 84 |  7 | ANCE | Pertaining to forbearers of an individual. | Pertaining to forebearers of an individual. | Change "forbearers" to "forebearers" |
 | 83 | 28 | Lineage-Linked GEDCOM Tag Definitions | | **ADR3 {ADDRESS3}:=** | Add ADR3 after ADR2 |
 | 83 | 28 | Lineage-Linked GEDCOM Tag Definitions | | The third line of an address. | |


### PR DESCRIPTION
Addresses most field size parts of
    https://github.com/FamilySearch/GEDCOM/issues/640
and
    https://github.com/FamilySearch/GEDCOM/issues/645

The points regarding NUMBER and MULTIMEDIA_FILE_REFERENCE field sizes require more discussion and so are outside the scope of this particular PR.