### PR TITLE
Add YAML schema file for v5.5.1

### DIFF
--- a/yaml-schema-v5.5.1.yaml
+++ b/yaml-schema-v5.5.1.yaml
@@ -1,0 +1,131 @@
+---
+"$schema": "https://json-schema.org/draft/2020-12"
+
+type: object
+
+definitions:
+  uri:
+    type: string
+    simpler-pattern: "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$"
+    pattern: "^([A-Za-z]([A-Za-z0-9]|\\+|\\-|\\.)*)\\:(//(((([-A-Z._a-z0-9]|~)|%[0-9A-Fa-f][0-9A-Fa-f]|(\\!|\\$|&|'|\\(|\\)|\\*|\\+|,|;|\\=)|\\:)*)@)?((\\[((([0-9A-Fa-f]{1,4}\\:){6}(([0-9A-Fa-f]{1,4}\\:[0-9A-Fa-f]{1,4})|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|\\:\\:([0-9A-Fa-f]{1,4}\\:){5}(([0-9A-Fa-f]{1,4}\\:[0-9A-Fa-f]{1,4})|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|([0-9A-Fa-f]{1,4})?\\:\\:([0-9A-Fa-f]{1,4}\\:){4}(([0-9A-Fa-f]{1,4}\\:[0-9A-Fa-f]{1,4})|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}\\:){,1}[0-9A-Fa-f]{1,4})?\\:\\:([0-9A-Fa-f]{1,4}\\:){3}(([0-9A-Fa-f]{1,4}\\:[0-9A-Fa-f]{1,4})|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}\\:){,2}[0-9A-Fa-f]{1,4})?\\:\\:([0-9A-Fa-f]{1,4}\\:){2}(([0-9A-Fa-f]{1,4}\\:[0-9A-Fa-f]{1,4})|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}\\:){,3}[0-9A-Fa-f]{1,4})?\\:\\:[0-9A-Fa-f]{1,4}\\:(([0-9A-Fa-f]{1,4}\\:[0-9A-Fa-f]{1,4})|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}\\:){,4}[0-9A-Fa-f]{1,4})?\\:\\:(([0-9A-Fa-f]{1,4}\\:[0-9A-Fa-f]{1,4})|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}\\:){,5}[0-9A-Fa-f]{1,4})?\\:\\:[0-9A-Fa-f]{1,4}|(([0-9A-Fa-f]{1,4}\\:){,6}[0-9A-Fa-f]{1,4})?\\:\\:)|([Vv][0-9A-Fa-f]+\\.(([-A-Z._a-z0-9]|~)|(\\!|\\$|&|'|\\(|\\)|\\*|\\+|,|;|\\=)|\\:)+))\\])|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])|((([-A-Z._a-z0-9]|~)|%[0-9A-Fa-f][0-9A-Fa-f]|(\\!|\\$|&|'|\\(|\\)|\\*|\\+|,|;|\\=))*))(\\:[0-9]*)?(/(([-A-Z._a-z0-9]|~)|%[0-9A-Fa-f][0-9A-Fa-f]|(\\!|\\$|&|'|\\(|\\)|\\*|\\+|,|;|\\=)|\\:|@)*)*|/((([-A-Z._a-z0-9]|~)|%[0-9A-Fa-f][0-9A-Fa-f]|(\\!|\\$|&|'|\\(|\\)|\\*|\\+|,|;|\\=)|\\:|@)+(/(([-A-Z._a-z0-9]|~)|%[0-9A-Fa-f][0-9A-Fa-f]|(\\!|\\$|&|'|\\(|\\)|\\*|\\+|,|;|\\=)|\\:|@)*)*)?|(([-A-Z._a-z0-9]|~)|%[0-9A-Fa-f][0-9A-Fa-f]|(\\!|\\$|&|'|\\(|\\)|\\*|\\+|,|;|\\=)|\\:|@)+(/(([-A-Z._a-z0-9]|~)|%[0-9A-Fa-f][0-9A-Fa-f]|(\\!|\\$|&|'|\\(|\\)|\\*|\\+|,|;|\\=)|\\:|@)*)*|MISSING-0(([-A-Z._a-z0-9]|~)|%[0-9A-Fa-f][0-9A-Fa-f]|(\\!|\\$|&|'|\\(|\\)|\\*|\\+|,|;|\\=)|\\:|@))(\\?(((([-A-Z._a-z0-9]|~)|%[0-9A-Fa-f][0-9A-Fa-f]|(\\!|\\$|&|'|\\(|\\)|\\*|\\+|,|;|\\=)|\\:|@)|/|\\?)*))?(#(((([-A-Z._a-z0-9]|~)|%[0-9A-Fa-f][0-9A-Fa-f]|(\\!|\\$|&|'|\\(|\\)|\\*|\\+|,|;|\\=)|\\:|@)|/|\\?)*))?$"
+
+  lang:
+    type: string
+    pattern: "^[a-zA-Z]{2,3}(-[a-zA-Z]{3}){0,3}|[a-zA-Z]{4,8}(-[a-zA-Z]{4})?(-[a-zA-Z]{2}|[0-9]{3})?(-[a-zA-Z]{5,8}|[0-9][a-zA-Z0-9]{3})*(-[0-9A-WY-Za-wy-z](-[a-zA-Z0-9]{2,8})+)*(-x(-[a-zA-Z0-9]{1,8})+)?|x(-[a-zA-Z0-9]{1,8})+|en-GB-oed|i-(ami|bnn|default|enochian|hak|klingon|lux|mingo|navajo|pwn|tao|tay|tsu)|sgn-(BE-(FR|NL)|CH-DE)$"
+  uris:
+    type: array
+    items:
+      "$ref": "#/definitions/uri"
+  card:
+    type: object
+    patternProperties:
+      "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$":
+        type: string
+        pattern: "^{[01]:[13M]}$"
+    additionalProperties: false
+
+properties:
+  type:
+    type: string
+    pattern: "^(structure|enumeration|calendar|month|data type|uri|enumeration set)$"
+  lang:
+    type: string
+  uri:
+    "$ref": "#/definitions/uri"
+  enumeration set:
+    "$ref": "#/definitions/uri"
+  standard tag:
+    type: string
+    pattern: "^[A-Z0-9_]+$"
+  extension tags:
+    type: array
+    items:
+      type: string
+      pattern: "^_[A-Z0-9_]+$"
+  payload:
+    type: ["null", string]
+    pattern: "^Y\\|<NULL>$|^@<^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?>@$|^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$"
+  documentation:
+    "$ref": "#/definitions/uris"
+  enumeration values:
+    "$ref": "#/definitions/uris"
+  calendars:
+    "$ref": "#/definitions/uris"
+  months:
+    "$ref": "#/definitions/uris"
+  epochs:
+    type: array
+    items:
+      type: string
+      pattern: "^(B\\.C\\.|_[A-Z0-9_]+)$"
+  value of:
+    "$ref": "#/definitions/uris"
+  specification:
+    type: array
+    items:
+      type: string
+  label:
+    type: string
+  help text:
+    type: string
+  substructures:
+    "$ref": "#/definitions/card"
+  superstructures:
+    "$ref": "#/definitions/card"
+  subsumes:
+    "$ref": "#/definitions/uris"
+  contact:
+    type: string
+  change controller:
+    type: string
+  fragment:
+    type: string
+  prerelease:
+    type: boolean
+  translated from:
+    type: string
+  used by:
+    type: array
+    items:
+      type: string
+
+additionalProperties: false
+
+required:
+  - type
+  - lang
+  - uri
+
+allOf:
+  - if: {properties: {type: {const: structure}}}
+    then: {required: [substructures, superstructures, payload, specification]}
+  - if: {properties: {type: {const: enumeration}}}
+    then: {required: [specification, value of]}
+  - if: {properties: {type: {const: calendar}}}
+    then: {required: [specification, months, epochs]}
+  - if: {properties: {type: {const: month}}}
+    then: {required: [calendars]}
+  - if: {properties: {type: {const: data type}}}
+    then: {required: [specification]}
+  - if: {properties: {type: {const: uri}}}
+    then: {required: [specification]}
+  - if: {properties: {type: {const: enumeration set}}}
+    then: {required: [enumeration values]}
+
+  - if:
+      properties:
+        type: {const: structure}
+        payload:
+          type: string
+          pattern: '^https://gedcom.io/terms/v7/type-(List#)?Enum$'
+    then: {required: [enumeration set]}
+    else: {not: {required: [enumeration set]}}
+
+  - if:
+      properties:
+        type:
+          pattern: "^(structure|enumeration|calendar|month)$"
+    then:
+      oneOf:
+        - {required: [standard tag]}
+        - {required: [extension tags]}


### PR DESCRIPTION
This is a prerequisite for https://github.com/FamilySearch/GEDCOM/issues/572 This is a separate YAML file so that the YAML validator can use the right schema based on the relevant GEDCOM version.

Differences from yaml-schema.yaml include:
* "{0:3}" is a permitted cardinality
* Epoch is "B.C." instead of "BCE" (but whether this is needed depends on whether we actually need to allow registering extension calendars in 5.5.1 or not)

However, this can be tricky to consume.  If one registers an extension that works with both v7 and v5.5.1, which schema do you apply to the extension's YAML file or are two extension files required?   Perhaps we say that a single file is fine if it validates according to both schema files and two files (with `subsumes`) are only required if not?   (I don't know of any cases that would happen but it is theoretically possible)

A simpler possibility would be to just add "{0:3}" to the existing yaml-schema.yaml file (instead of creating a separate schema file for 5.5.1) even though it's not used by the v7 standard.  This is worth a discussion about which approach to take, especially in light of a desire that extensions should be version-agnostic, and there may be extensions already out there in 5.5.1 that use "{0:3}" for their extension, such as relocating a standard "{0:3}" 5.5.1 structure (PHON, EMAIL, FAX, WWW, LANG).