### PR TITLE
Add "nonconformant tags" to v5.5.1 schema

### DIFF
--- a/yaml-schema-v5.5.1.yaml
+++ b/yaml-schema-v5.5.1.yaml
@@ -42,6 +42,11 @@ properties:
     items:
       type: string
       pattern: "^_[A-Z0-9_]+$"
+  nonconformant tags:
+    type: array
+    items:
+      type: string
+      pattern: "^[A-Z0-9_]+$"
   payload:
     type: ["null", string]
     pattern: "^Y\\|<NULL>$|^@<^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?>@$|^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$"


### PR DESCRIPTION
PR #302 added it to the v7 schema but not the v5.5.1 schema where it is even more needed.