### PR TITLE
Bump GedValidate to v1.3.0

### DIFF
--- a/.github/workflows/validate-gedcom.yml
+++ b/.github/workflows/validate-gedcom.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Download GedValidate
         shell: pwsh
-        run: Invoke-WebRequest https://github.com/ArmidaleSoftware/gedcom7/releases/download/v1.2.0/Windows-Release-GedValidate.zip -OutFile GedValidate.zip
+        run: Invoke-WebRequest https://github.com/ArmidaleSoftware/gedcom7/releases/download/v1.3.0/Windows-Release-GedValidate.zip -OutFile GedValidate.zip
 
       - name: Unzip GedValidate
         shell: pwsh


### PR DESCRIPTION
To support the new GEDCOM 7.0 data type URIs.