### PR TITLE
Typo in nonconformant tag spec

### DIFF
--- a/_pages/yaml-file-format.md
+++ b/_pages/yaml-file-format.md
@@ -213,7 +213,7 @@ Their names may be changed a YAML file with a `lang` other than `en`.
 -   <table><tbody>
     <tr><th>Key</th><td><code>nonconformant tags</code></td></tr>
     <tr><th>Type</th><td><code>seq</code> of <code>stdTag</code></td></tr>
-    <tr><th>Required by</th><td>*</td></tr>
+    <tr><th>Required by</th><td>—</td></tr>
     <tr><th>Allowed by</th><td><code>type</code>s <code>calendar</code>, <code>enumeration</code>, <code>month</code>, <code>structure</code></td></tr>
     </tbody></table>
     


### PR DESCRIPTION
Replace "\*" with "—" to represent "none"