### PR TITLE
Fix indentation of surrogacy question

### DIFF
--- a/_pages/techfaqs.md
+++ b/_pages/techfaqs.md
@@ -351,7 +351,7 @@ Certain additional information about specific aspects of a parent-child relation
 
 - `SLGC`.`FAMC` indicates a recognition of a persons parents by the Church of Jesus Christ of Latter-Day Saints.
 
-# How do I record surrogacy?
+## How do I record surrogacy?
 
 The specification notes that `INDI`.`FAMC`.`PEDI BIRTH` can be used to mean either "genetic parent"
 or "social parent at time of birth", so applications should refrain from assuming it has


### PR DESCRIPTION
https://gedcom.io/techfaqs/ currently incorrectly shows "How do I record surrogacy?" as a section heading.
It should be a question under the "Parent-Child Relationships" section.