### PR TITLE
Fix formatting of YAML format description page

### DIFF
--- a/_pages/yaml-file-format.md
+++ b/_pages/yaml-file-format.md
@@ -228,9 +228,9 @@ Their names may be changed a YAML file with a `lang` other than `en`.
     <tr><th>Allowed by</th><td><code>type: uri</code></td></tr>
     </tbody></table>
     
-A recommended brief name or label for a fragment identifier, to show to users. Labels are user-centric; for programmer-centric explanations of the concept, see `specification`.
+    A recommended brief name or label for a fragment identifier, to show to users. Labels are user-centric; for programmer-centric explanations of the concept, see `specification`.
 
-Labels are short to fit in forms and other constrained-space UI elements; for more detailed text see `help text`.
+    Labels are short to fit in forms and other constrained-space UI elements; for more detailed text see `help text`.
     
     By being present in the YAML file, this field also implies that the URI should have a fragment identifier appended to it when used.
 


### PR DESCRIPTION
Fixing a formatting error where missing indentation changed presentation in confusing ways.